### PR TITLE
Fix 'More' text visibility issue on Knowledge Base page

### DIFF
--- a/templates/mytemplate/html/com_kb/articles/display.php
+++ b/templates/mytemplate/html/com_kb/articles/display.php
@@ -149,7 +149,7 @@ Document::setTitle(Lang::txt('COM_KB'));
 											</a>
 										</li>
 									<?php } ?>
-									<?php if ($row->articles()->count() > 3) : ?>
+									<?php if ($row->articles()->whereEquals('state', 1)->whereIn('access', User::getAuthorisedViewLevels())->rows()->count() > 3) : ?>
 										<li class="icon-file"><a href="<?php echo Route::url($row->link()); ?>">More...</a></li>
 									<?php endif; ?>
 									</ul>


### PR DESCRIPTION
Only categories with more than 3 articles should have the **More** link.
The possible problem with the old fix was that it counts all articles for a category without considering the state and access level of that article, and if that is larger than 3, **More** link is rendered.
The new solution take into account the state and access level of the article, which makes the total visible and accessible articles for each category less.