### PR TITLE
Fix file icon size when users are editing content for publications

### DIFF
--- a/templates/mytemplate/html/plg_projects_publications/curation.css
+++ b/templates/mytemplate/html/plg_projects_publications/curation.css
@@ -1265,3 +1265,7 @@
 		right: 0px !important;
 		padding: 0px;
 	}
+/* Fix file icon size when users editing content for publications */
+#abox-content .content-selector .file-selector img {
+	width: 50px;
+} 


### PR DESCRIPTION
The result should look like this 
![image](https://user-images.githubusercontent.com/55383509/224832495-c16835ba-4c48-4286-a0b0-e3d948c0728b.png)
Please check if this works with both folders and files.