### PR TITLE
Link to contributions page changed

### DIFF
--- a/plugins/members/contributions/views/display/tmpl/default.php
+++ b/plugins/members/contributions/views/display/tmpl/default.php
@@ -78,7 +78,7 @@ foreach ($this->cats as $cat)
 	<?php echo Lang::txt('PLG_MEMBERS_CONTRIBUTIONS'); ?>
 </h3>
 
-<form method="get" action="<?php Route::url($this->member->link() . '&active=contributions'); ?>">
+<form method="get" action="<?php Route::url($this->member->link() . '&active=contributions&area=' . urlencode('impact')); ?>">
 	<input type="hidden" name="area" value="<?php echo $this->escape($this->active) ?>" />
 
 	<div class="container">


### PR DESCRIPTION
Contributions menu link to https://hsscommons.ca/en/members/1198/contributions?area=impact rather than https://hsscommons.ca/en/members/1198/contributions. This way, they don't have to click "SEE MORE RESULTS" unnecessarily.