### PR TITLE
Remove extra alias code that is added to url path when switching language defaults

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -28,17 +28,17 @@ if (!function_exists('modifyLanguageLink')) {
 		// Remove the lang query parameter
 		$languageLink = preg_replace('/\?lang=[^&]+/', '', $languageLink);
 
-		// // Extract the parts of the path
-		// $pathParts = explode('/', $languageLink);
+		// Extract the parts of the path
+		$pathParts = explode('/', $languageLink);
 
-		// // Replace the content between the first set of slashes with $language->link
-		// if (count($pathParts) >= 2) {
-		// 	$language->link = trim($language->link, '/');
-		// 	$pathParts[1] = $language->link;
-		// }
+		// Replace the content between the first set of slashes with $language->link
+		if (count($pathParts) >= 2) {
+			$language->link = trim($language->link, '/');
+			$pathParts[1] = $language->link;
+		}
 
-		// // Rebuild the path
-		// $languageLink = '/' . implode('/', array_filter($pathParts));
+		// Rebuild the path
+		$languageLink = '/' . implode('/', array_filter($pathParts));
 
 		// Return the modified language link
 		return htmlspecialchars($languageLink);

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -32,9 +32,11 @@ if (!function_exists('modifyLanguageLink')) {
 		$pathParts = explode('/', $languageLink);
 
 		// Replace the content between the first set of slashes with $language->link
+		// and remove anything else that comes after it
 		if (count($pathParts) >= 2) {
 			$language->link = trim($language->link, '/');
 			$pathParts[1] = $language->link;
+			$pathParts = array_slice($pathParts, 0, 2);
 		}
 
 		// Rebuild the path


### PR DESCRIPTION
This pull request include a change to the `modifyLanguageLink` function in the `modules/mod_languages/tmpl/default.php` file. The change ensures that any extraneous parts of the path are removed after replacing the content between the first set of slashes with `$language->link`.
