### PR TITLE
Add custom mod_toptags language module with fr and es

### DIFF
--- a/modules/mod_toptags/composer.json
+++ b/modules/mod_toptags/composer.json
@@ -1,0 +1,22 @@
+{
+	"name": "hubzero/mod_toptags",
+	"description": "This module shows a list of tags in the HUBzero CMS",
+	"type": "hubzero-module",
+	"keywords": ["hubzero"],
+	"homepage": "https://hubzero.org",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "HUBzero",
+			"email": "support@hubzero.org"
+		}
+	],
+	"support": {
+		"email": "support@hubzero.org",
+		"issues": "https://help.hubzero.org"
+	},
+	"require": {
+		"php" : "^5.4",
+		"hubzero/com_tags": "dev-master"
+	}
+}

--- a/modules/mod_toptags/helper.php
+++ b/modules/mod_toptags/helper.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Modules\Toptags;
+
+use Hubzero\Module\Module;
+use Components\Tags\Models\Tag;
+
+/**
+ * Module class for displaying a tag cloud of most used tags
+ */
+class Helper extends Module
+{
+	/**
+	 * Get module contents
+	 *
+	 * @return  void
+	 */
+	public function run()
+	{
+		require_once \Component::path('com_tags') . DS . 'models' . DS . 'cloud.php';
+
+		$this->tags = Tag::all()
+			->whereEquals('admin', 0)
+			->limit((int)$this->params->get('numtags', 25))
+			->order('objects', 'desc')
+			->rows();
+
+		require $this->getLayoutPath();
+	}
+
+	/**
+	 * Display module
+	 *
+	 * @return  void
+	 */
+	public function display()
+	{
+		if ($content = $this->getCacheContent())
+		{
+			echo $content;
+			return;
+		}
+
+		$this->run();
+	}
+}

--- a/modules/mod_toptags/language/en-GB/en-GB.mod_toptags.ini
+++ b/modules/mod_toptags/language/en-GB/en-GB.mod_toptags.ini
@@ -1,0 +1,32 @@
+; @package      hubzero-cms
+; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @license      http://opensource.org/licenses/MIT MIT
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+MOD_TOPTAGS="Top Tags"
+MOD_TOPTAGS_XML_DESCRIPTION="This module shows a list of tags."
+
+MOD_TOPTAGS_MORE="More &rsaquo;"
+
+; Parameters
+MOD_TOPTAGS_PARAM_NUMTAGS_LABEL="Number of tags"
+MOD_TOPTAGS_PARAM_NUMTAGS_DESC="The number of tags to display."
+MOD_TOPTAGS_PARAM_EXCLUDED_LABEL="Excluded Tags"
+MOD_TOPTAGS_PARAM_EXCLUDED_DESC="List of tags to exclude from the tags list."
+MOD_TOPTAGS_PARAM_MESSAGE_LABEL="Message"
+MOD_TOPTAGS_PARAM_MESSAGE_DESC="The message to be displayed if no tags are found"
+MOD_TOPTAGS_PARAM_SORT_LABEL="Sort by"
+MOD_TOPTAGS_PARAM_SORT_DESC="The sort order for tags found"
+MOD_TOPTAGS_PARAM_SORT_ALPHA="Alphabetically"
+MOD_TOPTAGS_PARAM_SORT_POPULARITY="By Popularity"
+MOD_TOPTAGS_PARAM_MORE_LABEL="More links"
+MOD_TOPTAGS_PARAM_MORE_DESC="Display a link to more tags"
+MOD_TOPTAGS_PARAM_MORE_SHOW="Show"
+MOD_TOPTAGS_PARAM_MORE_HIDE="Hide"
+
+; Caching
+MOD_TOPTAGS_PARAM_CACHE_LABEL="Enable Cache"
+MOD_TOPTAGS_PARAM_CACHE_DESC="Select whether to cache the content of this module"
+MOD_TOPTAGS_PARAM_CACHETIME_LABEL="Cache Time"
+MOD_TOPTAGS_PARAM_CACHETIME_DESC="The time before the module is recached"

--- a/modules/mod_toptags/language/en-GB/en-GB.mod_toptags.sys.ini
+++ b/modules/mod_toptags/language/en-GB/en-GB.mod_toptags.sys.ini
@@ -1,0 +1,8 @@
+; @package      hubzero-cms
+; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @license      http://opensource.org/licenses/MIT MIT
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+MOD_TOPTAGS="Top Tags"
+MOD_TOPTAGS_XML_DESCRIPTION="This module shows a list of tags."

--- a/modules/mod_toptags/language/es/es.mod_toptags.ini
+++ b/modules/mod_toptags/language/es/es.mod_toptags.ini
@@ -1,0 +1,32 @@
+; @package      hubzero-cms
+; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @license      http://opensource.org/licenses/MIT MIT
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+MOD_TOPTAGS="Etiquetas principales"
+MOD_TOPTAGS_XML_DESCRIPTION="Este módulo muestra una lista de etiquetas."
+
+MOD_TOPTAGS_MORE="Más &rsaquo;"
+
+; Parameters
+MOD_TOPTAGS_PARAM_NUMTAGS_LABEL="Número de etiquetas"
+MOD_TOPTAGS_PARAM_NUMTAGS_DESC="El número de etiquetas a mostrar."
+MOD_TOPTAGS_PARAM_EXCLUDED_LABEL="Etiquetas excluidas"
+MOD_TOPTAGS_PARAM_EXCLUDED_DESC="Lista de etiquetas a excluir de la lista de etiquetas."
+MOD_TOPTAGS_PARAM_MESSAGE_LABEL="Mensaje"
+MOD_TOPTAGS_PARAM_MESSAGE_DESC="El mensaje que se mostrará si no se encuentran etiquetas"
+MOD_TOPTAGS_PARAM_SORT_LABEL="Ordenar por"
+MOD_TOPTAGS_PARAM_SORT_DESC="El orden de clasificación de las etiquetas encontradas"
+MOD_TOPTAGS_PARAM_SORT_ALPHA="Alfabéticamente"
+MOD_TOPTAGS_PARAM_SORT_POPULARITY="Por popularidad"
+MOD_TOPTAGS_PARAM_MORE_LABEL="Más enlaces"
+MOD_TOPTAGS_PARAM_MORE_DESC="Mostrar un enlace a más etiquetas"
+MOD_TOPTAGS_PARAM_MORE_SHOW="Mostrar"
+MOD_TOPTAGS_PARAM_MORE_HIDE="Ocultar"
+
+; Caching
+MOD_TOPTAGS_PARAM_CACHE_LABEL="Habilitar caché"
+MOD_TOPTAGS_PARAM_CACHE_DESC="Seleccionar si se debe almacenar en caché el contenido de este módulo"
+MOD_TOPTAGS_PARAM_CACHETIME_LABEL="Tiempo de caché"
+MOD_TOPTAGS_PARAM_CACHETIME_DESC="El tiempo antes de que el módulo se vuelva a almacenar en caché"

--- a/modules/mod_toptags/language/fr/fr.mod_toptags.ini
+++ b/modules/mod_toptags/language/fr/fr.mod_toptags.ini
@@ -1,0 +1,32 @@
+; @package      hubzero-cms
+; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @license      http://opensource.org/licenses/MIT MIT
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+MOD_TOPTAGS="Tags Principaux"
+MOD_TOPTAGS_XML_DESCRIPTION="Ce module affiche une liste de tags."
+
+MOD_TOPTAGS_MORE="Plus &rsaquo;"
+
+; Parameters
+MOD_TOPTAGS_PARAM_NUMTAGS_LABEL="Nombre de tags"
+MOD_TOPTAGS_PARAM_NUMTAGS_DESC="Le nombre de tags à afficher."
+MOD_TOPTAGS_PARAM_EXCLUDED_LABEL="Tags exclus"
+MOD_TOPTAGS_PARAM_EXCLUDED_DESC="Liste des tags à exclure de la liste des tags."
+MOD_TOPTAGS_PARAM_MESSAGE_LABEL="Message"
+MOD_TOPTAGS_PARAM_MESSAGE_DESC="Le message à afficher si aucun tag n'est trouvé"
+MOD_TOPTAGS_PARAM_SORT_LABEL="Trier par"
+MOD_TOPTAGS_PARAM_SORT_DESC="L'ordre de tri des tags trouvés"
+MOD_TOPTAGS_PARAM_SORT_ALPHA="Alphabétiquement"
+MOD_TOPTAGS_PARAM_SORT_POPULARITY="Par popularité"
+MOD_TOPTAGS_PARAM_MORE_LABEL="Plus de liens"
+MOD_TOPTAGS_PARAM_MORE_DESC="Afficher un lien vers plus de tags"
+MOD_TOPTAGS_PARAM_MORE_SHOW="Afficher"
+MOD_TOPTAGS_PARAM_MORE_HIDE="Cacher"
+
+; Caching
+MOD_TOPTAGS_PARAM_CACHE_LABEL="Activer le cache"
+MOD_TOPTAGS_PARAM_CACHE_DESC="Sélectionner si le contenu de ce module doit être mis en cache"
+MOD_TOPTAGS_PARAM_CACHETIME_LABEL="Durée du cache"
+MOD_TOPTAGS_PARAM_CACHETIME_DESC="Le temps avant que le module ne soit mis en cache à nouveau"

--- a/modules/mod_toptags/mod_toptags.php
+++ b/modules/mod_toptags/mod_toptags.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Modules\Toptags;
+
+require_once __DIR__ . DS . 'helper.php';
+
+with(new Helper($params, $module))->display();

--- a/modules/mod_toptags/mod_toptags.xml
+++ b/modules/mod_toptags/mod_toptags.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="1.5.0" client="site" type="module">
+	<name>Top Tags</name>
+	<author>HUBzero</author>
+	<authorUrl>hubzero.org</authorUrl>
+	<authorEmail>support@hubzero.org</authorEmail>
+	<copyright>Copyright (c) 2005-2020 The Regents of the University of California.</copyright>
+	<license>http://opensource.org/licenses/MIT MIT</license>
+	<description>MOD_TOPTAGS_XML_DESCRIPTION</description>
+	<files>
+		<filename module="mod_toptags">mod_toptags.php</filename>
+		<filename>tmpl/default.php</filename>
+		<filename>tmpl/index.html</filename>
+		<filename>mod_toptags.xml</filename>
+		<filename>index.html</filename>
+	</files>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field name="numtags" type="text" default="25" label="MOD_TOPTAGS_PARAM_NUMTAGS_LABEL" description="MOD_TOPTAGS_PARAM_NUMTAGS_DESC" />
+				<field name="exclude" type="textarea" rows="3" cols="40" default="" label="MOD_TOPTAGS_PARAM_EXCLUDED_LABEL" description="MOD_TOPTAGS_PARAM_EXCLUDED_DESC" />
+				<field name="message" type="textarea" rows="3" cols="40" default="No tags found." label="MOD_TOPTAGS_PARAM_MESSAGE_LABEL" description="MOD_TOPTAGS_PARAM_MESSAGE_DESC" />
+				<field name="sortby" type="list" default="alphabeta" label="MOD_TOPTAGS_PARAM_SORT_LABEL" description="MOD_TOPTAGS_PARAM_SORT_DESC">
+					<option value="alphabeta">MOD_TOPTAGS_PARAM_SORT_ALPHA</option>
+					<option value="popularity">MOD_TOPTAGS_PARAM_SORT_POPULARITY</option>
+				</field>
+				<field name="morelnk" type="radio" default="0" label="MOD_TOPTAGS_PARAM_MORE_LABEL" description="MOD_TOPTAGS_PARAM_MORE_DESC">
+					<option value="0">MOD_TOPTAGS_PARAM_MORE_HIDE</option>
+					<option value="1">MOD_TOPTAGS_PARAM_MORE_SHOW</option>
+				</field>
+			</fieldset>
+			<fieldset name="advanced">
+				<field name="cache" type="list" default="0" label="MOD_TOPTAGS_PARAM_CACHE_LABEL" description="MOD_TOPTAGS_PARAM_CACHE_DESC">
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
+				</field>
+				<field name="cache_time" type="text" default="900" label="MOD_TOPTAGS_PARAM_CACHETIME_LABEL" description="MOD_TOPTAGS_PARAM_CACHETIME_DESC" />
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/modules/mod_toptags/tmpl/default.php
+++ b/modules/mod_toptags/tmpl/default.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+$exclude = explode(',', $this->params->get('exclude', ''));
+$exclude = array_map('trim', $exclude);
+
+$tl = array();
+if ($this->tags->count() > 0)
+{
+	$html  = '<ol class="tags">' . "\n";
+	foreach ($this->tags as $tag)
+	{
+		if (!in_array($tag->get('raw_tag'), $exclude))
+		{
+			$tl[$tag->get('tag')] = "\t" . '<li><a class="tag" href="' . Route::url('index.php?option=com_tags&tag=' . $this->escape($tag->get('tag'))) . '">' . $this->escape($tag->get('raw_tag')) . '</a></li>';
+		}
+	}
+	if ($this->params->get('sortby') == 'alphabeta')
+	{
+		ksort($tl);
+	}
+	$html .= implode("\n", $tl);
+	$html .= '</ol>' . "\n";
+	if ($this->params->get('morelnk'))
+	{
+		$html .= '<p class="more"><a href="' . Route::url('index.php?option=com_tags') . '">' . Lang::txt('MOD_TOPTAGS_MORE') . '</a></p>' . "\n";
+	}
+}
+else
+{
+	$html  = '<p>' . $this->params->get('message', 'No tags found.') . '</p>' . "\n";
+}
+echo $html;


### PR DESCRIPTION
Testing to see if adding the mod_toptags module into the HSSCommons overlay, and including new french and spanish translations allows the browse content module to appear in the foreign language Home pages. 