### PR TITLE
Add checkbox that acts as a primary_files filter for publications/browse

### DIFF
--- a/components/com_publications/site/views/browse/tmpl/default.php
+++ b/components/com_publications/site/views/browse/tmpl/default.php
@@ -30,6 +30,12 @@ $this->css()
 						<input type="hidden" name="sortby" value="<?php echo $this->escape($this->filters['sortby']); ?>" />
 						<input type="hidden" name="tag" value="<?php echo $this->escape($this->filters['tag']); ?>" />
 					</fieldset>
+					<div>
+                        <label for="filter-primary-files">
+                            <input type="checkbox" id="filter-primary-files" name="filter_primary_files" value="1" <?php echo ($this->filters['primary_files']) ? 'checked="checked"' : ''; ?>>
+                            <?php echo Lang::txt('Only display publications with primary files'); ?>
+                        </label>
+                    </div>
 					<?php if ($this->filters['tag']) { ?>
 						<div class="applied-tags">
 							<ol class="tags">


### PR DESCRIPTION
Add a checkbox to the repos publications browse function that acts a primary files filter. 
- The filter function currently searches for the term 'primary_file'. This may change based on how we make primary files optional via the backend. 