### PR TITLE
Add checkbox to filter primary_files in publications 

### DIFF
--- a/components/com_publications/site/views/browse/tmpl/default.php
+++ b/components/com_publications/site/views/browse/tmpl/default.php
@@ -32,7 +32,7 @@ $this->css()
 					</fieldset>
 					<div>
                         <label for="filter-primary-files">
-                            <input type="checkbox" id="filter-primary-files" name="filter_primary_files" value="1" <?php echo ($this->filters['primary_files']) ? 'checked="checked"' : ''; ?>>
+                            <input type="checkbox" id="filter-primary-files" name="filter_primary_files" value="1" >
                             <?php echo Lang::txt('Only display publications with primary files'); ?>
                         </label>
                     </div>


### PR DESCRIPTION
The re-adds the checkbox in the repos->publications->browse search function. 
It will eventually filter out files that are not primary_files, but for now acts a dummy feature until the backend functionality is implemented. 