### PR TITLE
Correct previous redirect for member contributions page

### DIFF
--- a/plugins/members/contributions/views/display/tmpl/default.php
+++ b/plugins/members/contributions/views/display/tmpl/default.php
@@ -173,9 +173,7 @@ foreach ($this->results as $category)
 			$html .= call_user_func(array($obj, 'documents'));
 		}
 
-		// $ttl = ($total > 5) ? 5 : $total;
-		// $ttl = $total is a trivial way of making the contributions page open to all results
-		$ttl = $total;
+		$ttl = ($total > 5) ? 5 : $total;
 		if (!$dopaging)
 		{
 			$num = '1-' . $ttl . ' of ';

--- a/templates/mytemplate/html/com_members/profiles/view.php
+++ b/templates/mytemplate/html/com_members/profiles/view.php
@@ -172,6 +172,12 @@ $profileOrcid = $orcidRow->username;
 					}
 					$name = $c[$key];
 					$url = Route::url($this->profile->link() . '&active=' . $key);
+					
+					// If we are on the contributions tab, we need to add the area to the URL
+					if ($key == 'contributions') 
+					{
+						$url = Route::url($this->profile->link() . '&active=' . $key . '&area=impact');
+					}
 					$cls = ($this->active == $key) ? 'active' : '';
 					$tab_name = ($this->active == $key) ? $name : $tab_name;
 


### PR DESCRIPTION
This pull request includes changes to improve the functionality and user experience of the contributions display and profile view in the members plugin. The most important changes include fixing the contributions display logic and updating the URL routing for the contributions tab.

* Corrected the logic for setting the `$ttl` variable to ensure that the contributions page shows a maximum of 5 results unless the total is less than 5.

* Updated the URL routing to include an additional parameter (`area=impact`) when the contributions tab is active, improving navigation and user experience.