### PR TITLE
Add full translations to the home page defaults

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -40,6 +40,9 @@ if (!function_exists('modifyLanguageLink')) {
 		// Rebuild the path
 		$languageLink = '/' . implode('/', array_filter($pathParts));
 
+		// Remove all instances of 'home' from the rebuilt path
+        $languageLink = preg_replace('/\/home/', '', $languageLink);
+
 		// Return the modified language link
 		return htmlspecialchars($languageLink);
 	}


### PR DESCRIPTION
Changes in the code base are simple. There is an extra 'home' alias that is created in the default menu items for the non-English translations of the HSSCommons home page. These tend to 'stack' if you rotate between languages, causing 404 errors. The code changes look for the additional alias and remove it from the final rendered URL.

This PR accompanies a rather extensive set of admin backend changes:

* In the article manager, find the three Home articles for the languages. Make sure they are all published. To do so, click the status icon so that a green check mark appears.
* In the menu manager, two new menu items are created titled 'Home (French)' and 'Home (Spanish)'.
* Details for both are:
  - Menu item type: Single article
  - Alias: home
  - Default page: Yes
  - Language: French or Spanish
  - Select article: Home (must be set to the home article for the respective language)
* In the module manager, publish all French and Spanish modules that appear on the Home Page.
* To tell if an item appears on the home page, click on the module. At the bottom under the 'default' tab, the 'Home' box is selected. If the module is intended to be French or Spanish, de-select the Home box, and select the Home box for the respective language.
* Certain modules, such as 'Billboard', are featured on the Home page, but the language is set to 'all'. Make sure the Home box for the other languages is also selected in these cases.