### PR TITLE
Fix background canvas sizing

### DIFF
--- a/templates/mytemplate/css/theme.php
+++ b/templates/mytemplate/css/theme.php
@@ -75,12 +75,12 @@ switch ($bground)
 		$opacity = request('o1', '0.75');
 		$styles .= '
 		#outer-wrap {
-			background: transparent url("' . $tmpl . '/img/delauney.svg") 0 0 no-repeat;
+			background: transparent url("' . $tmpl . '/img/delauney.svg") 0 0 repeat-y;
 			background-size: 100% auto;
 		}
-		@media (max-width: 1000px) {
+		@media (max-width: 2200px) {
 			#outer-wrap {
-				background-size: 1000px auto;
+				background-size: 2200px auto;
 				background-position: 50% 0;
 			}
 		}


### PR DESCRIPTION
Addresses #249 


* Adjusted the CSS for the background image to not shrink as small when closing the browser window size. Now it the image minimizes to the a minimum of 2200px, whereas previously  it shrank to 1000px which revealed large parts of the blue canvas beneath the image. 
*  Tested the changes thoroughly to find the best visual option, which I believe to be the one I settled on. The image will shrink to a minimum of 2200 pixels on all pages of the site and the canvas will not be exposed. 