### PR TITLE
Match button styles to existing export links

### DIFF
--- a/components/com_publications/helpers/html.php
+++ b/components/com_publications/helpers/html.php
@@ -356,7 +356,7 @@ class Html
 				$html .= "\t\t\t" . '<button id="copy-button-' . $pub->id . '" class="btn copy-citation" data-target="citation-content-' . $pub->id . '">Copy Citation</button> <span>|</span> ' . "\n";
 				
 				// Add the "Export metadata as..." label
-				$html .= "\t\t\t" . '<span style="font-weight: normal; color: inherit; text-decoration: none;">Export metadata as... | </span> ' . "\n";
+				$html .= "\t\t\t" . '<span style="font-weight: normal; color: #666666; text-decoration: none;">Export metadata as... | </span> ' . "\n";
 
 				// Add the Export to .JSON button
 				$html .= "\t\t\t" . '<button id="export-button-' . $pub->id . '" class="btn-link export-jsoncitation" data-target="citation-content-' . $pub->id . '" title="Download in JSON format">JSON</button> <span>|</span> ' . "\n";

--- a/templates/mytemplate/css/index.css
+++ b/templates/mytemplate/css/index.css
@@ -10,7 +10,7 @@
   background: none;
   border: none;
   padding: 0;
-  color: #3181be;
+  color: #2677b5;
   cursor: pointer;
   font-style: italic;
   text-decoration: none;
@@ -21,7 +21,7 @@
   line-height: inherit;
 }
 .btn-link:hover {
-  color: black;
+  color: #444;
   text-decoration: underline;
 }
 .hide-text {


### PR DESCRIPTION
This pull request includes changes to update the styling of the citation export button and the button colors in the `index.css` file. The most important changes are as follows:

Styling updates:

* [`components/com_publications/helpers/html.php`](diffhunk://#diff-833e440bcfa109fa447f17722eb103636e71e6c4273f42c5b39dfd3da4eb58adL359-R359): Changed the color of the "Export metadata as..." label to `#666666` for better visibility.

Button color updates:

* [`templates/mytemplate/css/index.css`](diffhunk://#diff-71a41e73cfdca04fc8782fc659064166c4bbf530503efc6d4cf6c4f0a5f1413aL13-R13): Updated the button color from `#3181be` to `#2677b5` for a more consistent design.
* [`templates/mytemplate/css/index.css`](diffhunk://#diff-71a41e73cfdca04fc8782fc659064166c4bbf530503efc6d4cf6c4f0a5f1413aL24-R24): Modified the hover color of `.btn-link` from black to `#444` to match the updated design scheme.