### PR TITLE
Group page sidebar margins and stylings

### DIFF
--- a/components/com_groups/helpers/view.php
+++ b/components/com_groups/helpers/view.php
@@ -276,7 +276,7 @@ class View
 		$out = '';
 		if (count($pageArray) > 0)
 		{
-			$out = '<ul>';
+			$out = '<ul class="child-pages" style="margin-left: 10px;">';
 			foreach ($pageArray as $key => $page)
 			{
 				// dont show page links if there isnt an approved version
@@ -295,11 +295,11 @@ class View
 				if (($pageAccess == 'registered' && User::isGuest()) ||
 				  ($pageAccess == 'members' && !in_array(User::get("id"), $group->get('members'))))
 				{
-					$out .= "<li class=\"protected\"><span class=\"page\">" . $page->get('title') . "</span></li>";
+					$out .= "<li class=\"protected child-page\"><span class=\"page\">" . $page->get('title') . "</span></li>";
 				}
 				else
 				{
-					$out .= '<li class="' . $cls . '">';
+					$out .= '<li class="' . $cls . ' child-page">';
 					$out .= '<a class="page" title="' . $page->get('title') . '" href="' . $page->url() . '">' . $page->get('title') . '</a>';
 				}
 

--- a/components/com_groups/site/views/groups/tmpl/_menu.php
+++ b/components/com_groups/site/views/groups/tmpl/_menu.php
@@ -37,6 +37,9 @@ defined('_HZEXEC_') or die();
 				$trueTab = strtolower(Request::getString('active', 'overview'));
 				$liClass = ($trueTab != $this->tab) ? '' : $liClass;
 
+				// Add overview-dropdown class if there are pages
+				$liClass .= ' overview-dropdown';
+
 				if (($access == 'registered' && User::isGuest()) || ($access == 'members' && !in_array(User::get("id"), $this->group->get('members'))))
 				{
 					$item  = "<li class=\"protected group-overview-tab\"><span data-icon=\"&#x{$section['icon']};\" class=\"disabled overview\">Overview</span>";
@@ -50,7 +53,9 @@ defined('_HZEXEC_') or die();
 				// append pages html
 				// only pass in the children of the root node
 				// basically skip the overview page here
+				$item .= '<ul class="child-pages-container" style="margin-left: 10px;">';
 				$item .= \Components\Groups\Helpers\View::buildRecursivePageMenu($this->group, $this->pages[0]->get('children'));
+				$item .= '</ul>';
 			}
 			else
 			{

--- a/templates/mytemplate/html/com_groups/groups.css
+++ b/templates/mytemplate/html/com_groups/groups.css
@@ -410,6 +410,24 @@
 		text-align: left;
 	}
 
+	/* overview child pages */
+	.overview-dropdown:hover > .child-pages,
+	.overview-dropdown:focus-within > .child-pages-container {
+		display: block;
+	}
+	.child-pages {
+		background-color: #333;
+		z-index: 1;
+	}
+	.child-pages-container {
+		font-size: .825em;
+		line-height: 1.2;
+	}
+	.child-page {
+		color: #333;
+		background-color: transparent;
+		transition: background-color 0.15s;
+	}
 	#page_menu {
 		list-style: none;
 		margin: 0;


### PR DESCRIPTION
This pull request includes several changes to enhance the styling and functionality of the page menu in the groups component. The most important changes include adding new CSS classes and styles, modifying the HTML structure for better dropdown behavior, and updating the `buildRecursivePageMenu` function to include these new classes.

Styling and functionality enhancements:

* [`components/com_groups/helpers/view.php`](diffhunk://#diff-ad0c54d3915bf51a96dd0cd1ad559bf669dd42c9bfa279f6de9521626d340168L279-R279): Updated the `buildRecursivePageMenu` function to add the `child-pages` class to the unordered list and the `child-page` class to list items. [[1]](diffhunk://#diff-ad0c54d3915bf51a96dd0cd1ad559bf669dd42c9bfa279f6de9521626d340168L279-R279) [[2]](diffhunk://#diff-ad0c54d3915bf51a96dd0cd1ad559bf669dd42c9bfa279f6de9521626d340168L298-R302)
* [`components/com_groups/site/views/groups/tmpl/_menu.php`](diffhunk://#diff-d751c7fe2d5a6e6461087a9990cba184f9abd6edd4146d3130cef5ac3ceac5fbR40-R42): Added the `overview-dropdown` class to the list item if there are pages, and wrapped child pages in a container with the `child-pages-container` class. [[1]](diffhunk://#diff-d751c7fe2d5a6e6461087a9990cba184f9abd6edd4146d3130cef5ac3ceac5fbR40-R42) [[2]](diffhunk://#diff-d751c7fe2d5a6e6461087a9990cba184f9abd6edd4146d3130cef5ac3ceac5fbR56-R58)
* [`templates/mytemplate/html/com_groups/groups.css`](diffhunk://#diff-c8c1c13e0dd7e47fd16c0f15cb528f470de42f6a052ea5d627838e1f77d4214bR413-R430): Added new CSS rules for the `child-pages`, `child-pages-container`, and `child-page` classes to improve the appearance and behavior of the menu.