### PR TITLE
Add doi parsing to batch create

### DIFF
--- a/components/com_publications/admin/controllers/batchcreate.php
+++ b/components/com_publications/admin/controllers/batchcreate.php
@@ -333,6 +333,7 @@ class Batchcreate extends AdminController
 				$item['version']->description   = isset($node->abstract) ? trim($node->abstract) : '';
 				$item['version']->version_label = isset($node->version) ? trim($node->version) : '1.0';
 				$item['version']->release_notes = isset($node->notes) ? '<p>' . trim($node->notes) . '</p>' : '';
+				$item['version']->doi           = isset($node->doi) ? trim($node->doi) : '';
 
 				// Check license
 				$license = isset($node->license) ? $node->license : '';

--- a/components/com_publications/admin/import/publications.xsd
+++ b/components/com_publications/admin/import/publications.xsd
@@ -29,6 +29,7 @@
                                           <xs:element name="synopsis" type="xs:string"></xs:element>
                                           <xs:element name="abstract" type="xs:string"></xs:element>
                                           <xs:element name="version" type="xs:string" minOccurs="0"></xs:element>
+                                          <xs:element name="doi" type="xs:string" minOccurs="0"></xs:element>
 										  <xs:element name="category" type="xs:string" minOccurs="0"></xs:element>
                                           <xs:element name="notes" minOccurs="0" type="xs:string"></xs:element>
                                           <xs:element name="content">


### PR DESCRIPTION
This pull request includes updates to the `components/com_publications` module to add support for the Digital Object Identifier (DOI) field in publication records. The most important changes include modifications to the batch creation controller and the XML schema definition for publications.

Support for DOI field:

* [`components/com_publications/admin/controllers/batchcreate.php`](diffhunk://#diff-92c1a62ebdb875e9926558fe9fcfc59b1676369fe8927a6a5b92af8f0756cd20R336): Added a new line to set the `doi` field in the `parse` function if it is present in the node.
* [`components/com_publications/admin/import/publications.xsd`](diffhunk://#diff-d19ecc7cfaafb9902430109aa2ee48e2a5f230553ff23c19e9515232bca4efa2R32): Added a new XML element for `doi` with type `xs:string` and `minOccurs="0"` to the publications schema.