### PR TITLE
Change fr-FRlocalise to bnlocalise

### DIFF
--- a/bootstrap/site/language/bn/bn.localise.php
+++ b/bootstrap/site/language/bn/bn.localise.php
@@ -8,7 +8,7 @@
 /**
  * fr-FR localise class
  */
-abstract class fr_FRLocalise
+abstract class bnLocalise
 {
 	/**
 	 * Returns the potential suffixes for a specific number of items


### PR DESCRIPTION
This pull request includes a change to the `bootstrap/site/language/bn/bn.localise.php` file. The change updates the class name to match the Bengali localization.

- Changed the class name from `fr_FRLocalise` to `bnLocalise` in `bootstrap/site/language/bn/bn.localise.php` to reflect the correct localization.