### PR TITLE
Add array_values to an array that was skipping an index while iterati…

### DIFF
--- a/plugins/projects/team/team.php
+++ b/plugins/projects/team/team.php
@@ -794,7 +794,7 @@ class plgProjectsTeam extends \Hubzero\Plugin\Plugin
 				if ($this->model->get('sync_group'))
 				{
 					// Change the role that we are syncing group membership to
-					$paramsArray = array_filter(explode("\n", $this->model->get('params')));
+					$paramsArray = array_values(array_filter(explode("\n", $this->model->get('params'))));
 					$groupSyncedRoleFound = false;
 					for ($i = 0; $i < count($paramsArray); $i++) {
 						$param = $paramsArray[$i];


### PR DESCRIPTION
This pull request includes a small change to the `plugins/projects/team/team.php` file. The change ensures that the array of parameters is re-indexed after filtering out empty elements.

* [`plugins/projects/team/team.php`](diffhunk://#diff-102994e9e8c744f334c34cafb61d44133b8eec2e42bdb3f5e3f6711b1387ec8bL797-R797): Modified the `sync` function to use `array_values` after `array_filter` to ensure the array is re-indexed properly.…ng over it

- Fix error caused from iterating over incomplete array