### PR TITLE
Add inline styling for 2 html components

### DIFF
--- a/components/com_publications/helpers/html.php
+++ b/components/com_publications/helpers/html.php
@@ -260,7 +260,7 @@ class Html
 	public static function tabs($option, $id, $cats, $active = 'about', $alias = '', $version = '')
 	{
 		$html  = '';
-		$html .= "\t" . '<ul class="sub-menu">' . "\n";
+		$html .= "\t" . '<ul class="sub-menu" style="min-width: 335px; width: 100%; max-width: 100%;">' . "\n";
 		$i = 1;
 		foreach ($cats as $cat)
 		{

--- a/components/com_publications/site/views/about/tmpl/default.php
+++ b/components/com_publications/site/views/about/tmpl/default.php
@@ -46,7 +46,7 @@ $metaElements = new \Components\Publications\Models\Elements($data, $customField
 $schema = $metaElements->getSchema();
 
 ?>
-<div class="pubabout">
+<div class="pubabout" style="min-width: 320px; width: 100%; max-width: 100%; margin: 0 auto;">
 <?php
 	// Show gallery images
 	$modelHandler = new \Components\Publications\Models\Handlers($this->database);


### PR DESCRIPTION
This pull request includes changes to improve the layout and responsiveness of the publication components. The most important changes are related to updating the styles for better width control in the `tabs` and `about` sections.

Layout and responsiveness improvements:

* [`components/com_publications/helpers/html.php`](diffhunk://#diff-833e440bcfa109fa447f17722eb103636e71e6c4273f42c5b39dfd3da4eb58adL263-R263): Modified the `sections` function to update the `ul` element in the `tabs` method with new styles for minimum, maximum, and full width.
* [`components/com_publications/site/views/about/tmpl/default.php`](diffhunk://#diff-501c59b1a0a79a49c2358b93b3970bcea33b2479abc43db01ba40fcca568d858L49-R49): Updated the `div` element in the `about` section with new styles for minimum, maximum, and full width, and centered the content with margin adjustments.