### PR TITLE
Remove duplicate breadcrumbs

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -16,13 +16,28 @@ defined('_HZEXEC_') or die;
 	}
 
 	// Get rid of duplicated entries on trail including home page when using multilanguage
-	for ($i = 0; $i < $count; $i ++)
-	{
-		if ($i == 1 && !empty($list[$i]->link) && !empty($list[$i-1]->link) && $list[$i]->link == $list[$i-1]->link)
-		{
-			unset($list[$i]);
+	$deduped = [];
+	$lastItem = null;
+
+	foreach ($list as $item) {
+		if ($lastItem) {
+			$sameName = $item->name === $lastItem->name;
+			$sameOrNestedLink =
+				!empty($item->link) && !empty($lastItem->link) &&
+				(strpos($item->link, $lastItem->link) === 0 || strpos($lastItem->link, $item->link) === 0);
+
+			if ($sameName && $sameOrNestedLink) {
+				continue; // Skip duplicate-ish breadcrumb
+			}
 		}
+
+		$deduped[] = $item;
+		$lastItem = $item;
 	}
+
+	$list = $deduped;
+
+
 
 	// Find last and penultimate items in breadcrumbs list
 	end($list);


### PR DESCRIPTION
This pull request includes a significant change to the breadcrumb deduplication logic in the `modules/mod_breadcrumbs/tmpl/default.php` file. The main change involves replacing the previous loop-based deduplication method with a more efficient approach using a new array and a comparison of breadcrumb names and links.

Improvements to breadcrumb deduplication:

* [`modules/mod_breadcrumbs/tmpl/default.php`](diffhunk://#diff-b77c6e9e6f287b688b0499fcb811c7c506605d0000d4952e977cc201f32bca8bL19-R41): Replaced the old loop-based deduplication method with a new approach that uses an array (`$deduped`) and compares breadcrumb names and links to remove duplicates. This new method ensures that breadcrumbs with the same name and either the same or nested links are skipped, enhancing the efficiency and accuracy of the deduplication process.