### PR TITLE
Allow public projects to be accessible via Group pages

### DIFF
--- a/plugins/groups/projects/views/browse/tmpl/list.php
+++ b/plugins/groups/projects/views/browse/tmpl/list.php
@@ -57,7 +57,7 @@ switch ($this->which)
 				?>
 				<tr class="mline">
 					<td class="th_image">
-						<?php if ($row->access('member') || $row->access('readonly')) { ?>
+						<?php if ($row->isPublic() || $row->access('member') || $row->access('readonly')) { ?>
 							<a href="<?php echo Route::url($row->link()); ?>" title="<?php echo $this->escape($row->get('title')) . ' (' . $row->get('alias') . ')'; ?>">
 								<img src="<?php echo Route::url($row->link('thumb')); ?>" alt="<?php echo $this->escape($row->get('title')); ?>" class="project-image" />
 							</a>
@@ -72,7 +72,7 @@ switch ($this->which)
 						<?php if (!$row->isPublic()) { echo '<span class="privacy-icon">&nbsp;</span>'; } ?>
 					</td>
 					<td class="th_title">
-						<?php if ($row->access('member') || $row->access('readonly')) { ?>
+						<?php if ($row->isPublic() || $row->access('member') || $row->access('readonly')) { ?>
 							<a href="<?php echo Route::url($row->link()); ?>" title="<?php echo $this->escape($row->get('title')) . ' (' . $row->get('alias') . ')'; ?>">
 								<?php echo $this->escape($row->get('title')); ?>
 							</a>
@@ -86,6 +86,7 @@ switch ($this->which)
 					<td class="th_status">
 						<?php
 						$html = '';
+						$html .= '<span class="active"><a href="' . Route::url($row->link()) . '" title="' . Lang::txt('PLG_GROUPS_PROJECTS_GO_TO_PROJECT') . '">&raquo; ' . Lang::txt('PLG_GROUPS_PROJECTS_STATUS_ACTIVE') . '</a></span>';
 						if ($row->access('owner'))
 						{
 							if ($row->isActive())


### PR DESCRIPTION
This pull request updates the `list.php` template in the `plugins/groups/projects/views/browse/tmpl` directory to enhance project visibility and improve the user interface. The changes primarily focus on modifying access checks and adding a new status display for active projects.

### Enhancements to project visibility:

* Updated access checks to include public projects in two locations, ensuring that public projects are now visible to all users. (`plugins/groups/projects/views/browse/tmpl/list.php`, [[1]](diffhunk://#diff-a7edc880f68796a6dd2c7b0d58837adb363167caa2ccb890834339d2aefc722fL60-R60) [[2]](diffhunk://#diff-a7edc880f68796a6dd2c7b0d58837adb363167caa2ccb890834339d2aefc722fL75-R75)

### User interface improvements:

* Added a new "Active" status indicator with a link to the project, improving visibility and navigation for active projects. (`plugins/groups/projects/views/browse/tmpl/list.php`, [plugins/groups/projects/views/browse/tmpl/list.phpR89](diffhunk://#diff-a7edc880f68796a6dd2c7b0d58837adb363167caa2ccb890834339d2aefc722fR89))